### PR TITLE
고성능 컴퓨팅 환경에서 테스트 코드에서 무한 루프가 발생함.

### DIFF
--- a/test/observable.cpp
+++ b/test/observable.cpp
@@ -128,7 +128,7 @@ TEST(observable_test, observer_with_one_arg) {
       obj.test(-100);
       obj_1.test(-200);
       obj_2.test(-300);
-      std::this_thread::yield();
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
   });
   {


### PR DESCRIPTION
Xeon W-3175X에서 std::shared_mutex를 사용해서 동기화를 수행할때 yield를 사용하면 무한 루프가 발생하였음.
(std::shared_timed_shared를 사용하면 해당 증상이 발생하지 않음)
그래서 우선 sleep_for를 사용하여 스레드를 컨텍스트 스위칭이 되도록 처리함