### PR TITLE
[codex] Implement thread pool worker callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1316,6 +1316,9 @@ total.value(); // 60
 
 ### thread_pool
 
+Small fixed-size worker pool with future-returning task submission. Optional
+initializer/finalizer callbacks run once per worker thread.
+
 #### Requirements
 
 - GCC 8.3.0+
@@ -1326,6 +1329,24 @@ total.value(); // 60
 #### Examples
 
 ```C++
+#include <ext/thread_pool>
+#include <future>
+
+ext::thread_pool pool(
+    2,
+    []() {
+      // Initialize per-worker resources.
+      return true;
+    },
+    []() {
+      // Release per-worker resources.
+      return true;
+    });
+
+std::future<int> result = pool.queue([]() { return 42; });
+int value = result.get(); // 42
+
+pool.stop();
 ```
 
 ### type_traits

--- a/include/ext/thread_pool
+++ b/include/ext/thread_pool
@@ -20,6 +20,7 @@
 #include <mutex>
 #include <queue>
 #include <thread>
+#include <vector>
 
 namespace ext {
 /**
@@ -99,10 +100,13 @@ public:
    * @return false
    */
   bool start(size_t pool_size) {
-    if (status_ != stopped)
-      return false;
-    status_ = running;
-    pool_size_ = pool_size;
+    {
+      std::unique_lock<std::mutex> lock(mtx_);
+      if (status_ != stopped)
+        return false;
+      status_ = running;
+      pool_size_ = pool_size;
+    }
     for (size_t i = 0; i < pool_size_; i++)
 #if CXX_VER >= 201103L
       threads_.emplace_back(std::thread(std::bind(&thread_pool::woker_, this)));
@@ -118,18 +122,16 @@ public:
    * @param wait
    */
   void stop(bool wait = true) {
-    if (status_ != running)
-      return;
-
-    status_ = stop_pending;
-    cv_.notify_all();
-    if (wait) {
-      CXX_FOR(std::thread & thread, threads_) {
-        if (thread.joinable())
-          thread.join();
-      }
+    {
+      std::unique_lock<std::mutex> lock(mtx_);
+      if (status_ == stopped)
+        return;
+      if (status_ == running)
+        status_ = stop_pending;
     }
-    status_ = stopped;
+    cv_.notify_all();
+    if (wait)
+      join_threads_();
   }
 
   /**
@@ -151,14 +153,13 @@ public:
   std::future<typename CXX_INVOKE_RESULT(F, Args...)> queue(F &&fn,
                                                             Args &&... args) {
 #endif // CXX_RVALUE_REF_NOT_SUPPORTED
-    if (status_ != status::running)
-      throw std::runtime_error("This thread pool is not running");
-
     auto task = std::make_shared<
         std::packaged_task<typename CXX_INVOKE_RESULT(F, Args...)()>>(
         std::bind(std::forward<F>(fn), std::forward<Args>(args)...));
     {
       std::unique_lock<std::mutex> lock(mtx_);
+      if (status_ != status::running)
+        throw std::runtime_error("This thread pool is not running");
       queue_.push([task]() { (*task)(); });
     }
     cv_.notify_one();
@@ -166,13 +167,12 @@ public:
   }
 #else
   template <typename F> std::future<void> queue(F fn) {
-    if (status_ != running)
-      throw std::runtime_error("This thread pool is not running");
-
     std::shared_ptr<std::packaged_task<void>> task =
         std::make_shared<std::packaged_task<void>>(fn);
     {
       std::unique_lock<std::mutex> lock(mtx_);
+      if (status_ != running)
+        throw std::runtime_error("This thread pool is not running");
 #if defined(__cpp_lambdas)
       queue_.push([task]() { (*task)(); });
 #else
@@ -189,10 +189,19 @@ public:
    *
    * @return status
    */
-  status status() { return status_; }
+  status status() {
+    std::unique_lock<std::mutex> lock(mtx_);
+    return status_;
+  }
 
 private:
   void woker_() {
+    if (initializer_ && !initializer_()) {
+      if (finalizer_)
+        finalizer_();
+      return;
+    }
+
     std::function<void()> fn;
     for (;;) {
       {
@@ -204,13 +213,26 @@ private:
         cv_.wait(lk, std::bind(&thread_pool::wait_, this));
 #endif
         if (status_ != running)
-          return;
+          break;
 
         fn = queue_.front();
         queue_.pop();
       }
       fn();
     }
+
+    if (finalizer_)
+      finalizer_();
+  }
+
+  void join_threads_() {
+    CXX_FOR(std::thread & thread, threads_) {
+      if (thread.joinable())
+        thread.join();
+    }
+    threads_.clear();
+    std::unique_lock<std::mutex> lock(mtx_);
+    status_ = stopped;
   }
 #if !defined(__cpp_lambdas)
   bool wait_() { return !queue_.empty() || status_ != running; }

--- a/test/thread_pool.cpp
+++ b/test/thread_pool.cpp
@@ -1,0 +1,43 @@
+#include <ext/thread_pool>
+#include <gtest/gtest.h>
+
+#if defined(_EXT_THREAD_POOL_)
+#include <atomic>
+#include <future>
+
+TEST(thread_pool_test, worker_callbacks_are_called) {
+  std::atomic<int> initialized(0);
+  std::atomic<int> finalized(0);
+
+  ext::thread_pool pool(
+      3, [&initialized]() {
+        ++initialized;
+        return true;
+      },
+      [&finalized]() {
+        ++finalized;
+        return true;
+      });
+
+  std::future<int> result0 = pool.queue([]() { return 10; });
+  std::future<int> result1 = pool.queue([]() { return 20; });
+
+  EXPECT_EQ(10, result0.get());
+  EXPECT_EQ(20, result1.get());
+
+  pool.stop();
+
+  EXPECT_EQ(3, initialized.load());
+  EXPECT_EQ(3, finalized.load());
+  EXPECT_EQ(ext::thread_pool::stopped, pool.status());
+}
+
+TEST(thread_pool_test, stop_without_wait_is_joined_by_destructor) {
+  {
+    ext::thread_pool pool(1);
+    pool.stop(false);
+    EXPECT_EQ(ext::thread_pool::stop_pending, pool.status());
+  }
+  SUCCEED();
+}
+#endif


### PR DESCRIPTION
## Summary
- call `thread_pool` initializer callbacks once when each worker starts
- call finalizer callbacks once when each worker exits
- make `stop(false)` leave the pool in `stop_pending` while allowing destruction or a later waiting stop to join workers safely
- guard `thread_pool` status checks and transitions with the existing mutex
- add thread pool tests for worker callbacks and non-waiting stop cleanup
- document the thread pool callback example in the current README

## Verification
- `git diff --check`
- direct compile/run smoke test with `c++ -std=c++17 -pthread -Iinclude` covering callback counts and `stop(false)` destruction
- README code-fence balance check
- full CMake test flow was not run because this environment does not have `cmake` installed (`cmake: command not found`)

## Notes
- Retargeted to `master` after #26 was merged.