### PR TITLE
[codex] Implement cancellable thread pool tasks

### DIFF
--- a/docs/api/thread_pool.md
+++ b/docs/api/thread_pool.md
@@ -16,6 +16,8 @@ Creates worker threads that consume queued packaged tasks. The API is intentiona
 - Constructors may accept per-worker initializer and finalizer callbacks.
 - `start(pool_size)` creates worker threads when the pool is stopped.
 - `queue(fn, args...)` submits work and returns a `std::future` for the packaged task result.
+- `queue_cancellable(fn, args...)` submits work and returns a `queue_item<T>`
+  that can cancel the task before a worker starts executing it.
 - `stop(wait)` requests worker shutdown and optionally joins the worker threads.
 - `status()` reports `running`, `stop_pending`, or `stopped`.
 
@@ -24,6 +26,10 @@ Creates worker threads that consume queued packaged tasks. The API is intentiona
 - The pool requires standard thread, mutex, and condition variable support or configured Boost equivalents.
 - Task results and exceptions are surfaced through the returned `std::future`.
 - `queue()` throws when the pool is not running.
+- Canceling a pending `queue_item<T>` completes its future with
+  `ext::thread_pool::task_canceled`.
+- `queue_item<T>::cancel()` returns false once the task is already running,
+  completed, or previously canceled.
 - `stop()` changes the pool status and wakes workers; it does not promise to
   execute every task still waiting in the queue.
 - `stop(false)` requests shutdown without joining immediately; destruction or a
@@ -31,6 +37,8 @@ Creates worker threads that consume queued packaged tasks. The API is intentiona
 - The destructor calls `stop()`.
 - Worker initializer callbacks run once when each worker starts. Worker
   finalizer callbacks run once when each worker exits.
+- If any worker initializer returns false or throws, `start()` returns false and
+  the pool returns to the stopped state.
 
 ## Queue Contract
 
@@ -40,6 +48,8 @@ Creates worker threads that consume queued packaged tasks. The API is intentiona
   must complete.
 - Do not enqueue work after `stop()` has started; `queue()` rejects calls unless
   the pool status is `running`.
+- Use `queue_cancellable()` only for pre-execution cancellation. It does not
+  interrupt a task after a worker has started running it.
 
 ## Requirements
 
@@ -59,6 +69,24 @@ std::future<int> result = pool.queue([]() { return 42; });
 int value = result.get(); // 42
 pool.stop();
 ```
+
+- Cancel a pending task
+
+  ```C++
+  #include <ext/thread_pool>
+
+  ext::thread_pool pool(1);
+
+  ext::thread_pool::queue_item<int> item =
+      pool.queue_cancellable([]() { return 42; });
+  std::future<int> result = item.get_future();
+
+  if (item.cancel()) {
+    // result.get() throws ext::thread_pool::task_canceled.
+  }
+
+  pool.stop();
+  ```
 
 - Worker callbacks
 

--- a/docs/portability-and-contracts.md
+++ b/docs/portability-and-contracts.md
@@ -46,6 +46,7 @@ memory should read the API-specific behavior notes.
   callers that require all queued work to complete should wait on returned
   futures before stopping the pool. `stop(false)` requests shutdown without an
   immediate join; destruction or a later waiting stop still joins workers.
+  `queue_cancellable()` cancels only work that has not started running.
 - `observable` protects subscription bookkeeping when a shared mutex is
   available, but callbacks run synchronously from `notify()`. Avoid mutating
   subscriptions from inside an observer callback unless the specific locking

--- a/include/ext/thread_pool
+++ b/include/ext/thread_pool
@@ -15,10 +15,13 @@
 #define _EXT_THREAD_POOL_
 
 #include <condition_variable>
+#include <exception>
 #include <functional>
 #include <future>
+#include <memory>
 #include <mutex>
 #include <queue>
+#include <stdexcept>
 #include <thread>
 #include <vector>
 
@@ -34,26 +37,93 @@ class thread_pool {
 public:
   enum status { running, stop_pending, stopped };
 
+  class task_canceled : public std::runtime_error {
+  public:
+    task_canceled() : std::runtime_error("Task canceled.") {}
+  };
+
+private:
+  class queued_task_base {
+  public:
+    virtual ~queued_task_base() {}
+    virtual bool cancel() = 0;
+    virtual bool canceled() = 0;
+    virtual void run() = 0;
+  };
+
+  template <typename T> class queued_task : public queued_task_base {
+  public:
+    queued_task(std::function<T()> fn) : fn_(fn), state_(pending) {}
+
+    std::future<T> get_future() { return promise_.get_future(); }
+
+    bool cancel() {
+      std::unique_lock<std::mutex> lock(mtx_);
+      if (state_ != pending)
+        return false;
+      state_ = canceled_state;
+      promise_.set_exception(std::make_exception_ptr(task_canceled()));
+      return true;
+    }
+
+    bool canceled() {
+      std::unique_lock<std::mutex> lock(mtx_);
+      return state_ == canceled_state;
+    }
+
+    void run() {
+      {
+        std::unique_lock<std::mutex> lock(mtx_);
+        if (state_ == canceled_state)
+          return;
+        if (state_ != pending)
+          return;
+        state_ = executing;
+      }
+
+      try {
+        set_task_value_(promise_, fn_);
+      } catch (...) {
+        promise_.set_exception(std::current_exception());
+      }
+
+      std::unique_lock<std::mutex> lock(mtx_);
+      state_ = completed;
+    }
+
+  private:
+    enum task_state { pending, executing, canceled_state, completed };
+
+    std::function<T()> fn_;
+    std::promise<T> promise_;
+    std::mutex mtx_;
+    task_state state_;
+  };
+
+public:
   template <typename T> class queue_item {
   public:
-    queue_item(thread_pool *pool, std::shared_ptr<std::packaged_task<T()>> task)
-        : pool_(pool), task_(task) {}
+    queue_item() {}
+    queue_item(std::shared_ptr<queued_task<T>> task) : task_(task) {}
 
   public:
-    void cancel() {}
+    bool cancel() { return task_ && task_->cancel(); }
+
+    bool canceled() { return task_ && task_->canceled(); }
 
     std::future<T> get_future() { return task_->get_future(); }
 
   private:
-    thread_pool *pool_;
-    std::shared_ptr<std::packaged_task<T()>> task_;
+    std::shared_ptr<queued_task<T>> task_;
   };
 
   /**
    * @brief Construct a new thread pool object
    *
    */
-  thread_pool() : pool_size_(0), status_(stopped) {}
+  thread_pool()
+      : pool_size_(0), starting_workers_(0), started_workers_(0),
+        start_failed_(false), status_(stopped) {}
 
   /**
    * @brief Construct a new thread pool object
@@ -63,6 +133,7 @@ public:
    */
   thread_pool(initialize_callback initializer, finalize_callback finalizer)
       : initializer_(initializer), finalizer_(finalizer), pool_size_(0),
+        starting_workers_(0), started_workers_(0), start_failed_(false),
         status_(stopped) {}
 
   /**
@@ -70,7 +141,11 @@ public:
    *
    * @param pool_size
    */
-  thread_pool(size_t pool_size) : status_(stopped) { start(pool_size); }
+  thread_pool(size_t pool_size)
+      : pool_size_(0), starting_workers_(0), started_workers_(0),
+        start_failed_(false), status_(stopped) {
+    start(pool_size);
+  }
 
   /**
    * @brief Construct a new thread pool object
@@ -82,6 +157,7 @@ public:
   thread_pool(size_t pool_size, initialize_callback initializer,
               finalize_callback finalizer)
       : initializer_(initializer), finalizer_(finalizer), pool_size_(0),
+        starting_workers_(0), started_workers_(0), start_failed_(false),
         status_(stopped) {
     start(pool_size);
   }
@@ -106,6 +182,9 @@ public:
         return false;
       status_ = running;
       pool_size_ = pool_size;
+      starting_workers_ = pool_size;
+      started_workers_ = 0;
+      start_failed_ = false;
     }
     for (size_t i = 0; i < pool_size_; i++)
 #if CXX_VER >= 201103L
@@ -113,6 +192,21 @@ public:
 #else
       threads_.push_back(std::thread(std::bind(&thread_pool::woker_, this)));
 #endif
+    std::unique_lock<std::mutex> lock(mtx_);
+#if defined(__cpp_lambdas)
+    start_cv_.wait(lock, [this]() {
+      return start_failed_ || started_workers_ == starting_workers_;
+    });
+#else
+    start_cv_.wait(lock, std::bind(&thread_pool::start_wait_, this));
+#endif
+    if (start_failed_) {
+      status_ = stop_pending;
+      lock.unlock();
+      cv_.notify_all();
+      join_threads_();
+      return false;
+    }
     return true;
   }
 
@@ -153,34 +247,66 @@ public:
   std::future<typename CXX_INVOKE_RESULT(F, Args...)> queue(F &&fn,
                                                             Args &&... args) {
 #endif // CXX_RVALUE_REF_NOT_SUPPORTED
-    auto task = std::make_shared<
-        std::packaged_task<typename CXX_INVOKE_RESULT(F, Args...)()>>(
-        std::bind(std::forward<F>(fn), std::forward<Args>(args)...));
+    typedef typename CXX_INVOKE_RESULT(F, Args...) result_type;
+    std::shared_ptr<queued_task<result_type>> task =
+        make_task_<result_type>(std::bind(std::forward<F>(fn),
+                                          std::forward<Args>(args)...));
+    std::future<result_type> future = task->get_future();
     {
       std::unique_lock<std::mutex> lock(mtx_);
       if (status_ != status::running)
         throw std::runtime_error("This thread pool is not running");
-      queue_.push([task]() { (*task)(); });
+      queue_.push(task);
     }
     cv_.notify_one();
-    return task->get_future();
+    return future;
+  }
+
+  template <typename F, typename... Args>
+#ifdef CXX_RVALUE_REF_NOT_SUPPORTED
+  queue_item<typename CXX_INVOKE_RESULT(F, Args...)>
+  queue_cancellable(F fn, Args... args) {
+#else  // CXX_RVALUE_REF_NOT_SUPPORTED
+  queue_item<typename CXX_INVOKE_RESULT(F, Args...)>
+  queue_cancellable(F &&fn, Args &&... args) {
+#endif // CXX_RVALUE_REF_NOT_SUPPORTED
+    typedef typename CXX_INVOKE_RESULT(F, Args...) result_type;
+    std::shared_ptr<queued_task<result_type>> task =
+        make_task_<result_type>(std::bind(std::forward<F>(fn),
+                                          std::forward<Args>(args)...));
+    {
+      std::unique_lock<std::mutex> lock(mtx_);
+      if (status_ != status::running)
+        throw std::runtime_error("This thread pool is not running");
+      queue_.push(task);
+    }
+    cv_.notify_one();
+    return queue_item<result_type>(task);
   }
 #else
   template <typename F> std::future<void> queue(F fn) {
-    std::shared_ptr<std::packaged_task<void>> task =
-        std::make_shared<std::packaged_task<void>>(fn);
+    std::shared_ptr<queued_task<void>> task = make_task_<void>(fn);
+    std::future<void> future = task->get_future();
     {
       std::unique_lock<std::mutex> lock(mtx_);
       if (status_ != running)
         throw std::runtime_error("This thread pool is not running");
-#if defined(__cpp_lambdas)
-      queue_.push([task]() { (*task)(); });
-#else
-      queue_.push(std::bind(push_task_, task));
-#endif
+      queue_.push(task);
     }
     cv_.notify_one();
-    return task->get_future();
+    return future;
+  }
+
+  template <typename F> queue_item<void> queue_cancellable(F fn) {
+    std::shared_ptr<queued_task<void>> task = make_task_<void>(fn);
+    {
+      std::unique_lock<std::mutex> lock(mtx_);
+      if (status_ != running)
+        throw std::runtime_error("This thread pool is not running");
+      queue_.push(task);
+    }
+    cv_.notify_one();
+    return queue_item<void>(task);
   }
 #endif
 
@@ -196,13 +322,13 @@ public:
 
 private:
   void woker_() {
-    if (initializer_ && !initializer_()) {
-      if (finalizer_)
-        finalizer_();
+    if (!run_initializer_()) {
+      notify_worker_start_failed_();
       return;
     }
+    notify_worker_started_();
 
-    std::function<void()> fn;
+    std::shared_ptr<queued_task_base> task;
     for (;;) {
       {
         std::unique_lock<std::mutex> lk(mtx_);
@@ -215,14 +341,13 @@ private:
         if (status_ != running)
           break;
 
-        fn = queue_.front();
+        task = queue_.front();
         queue_.pop();
       }
-      fn();
+      task->run();
     }
 
-    if (finalizer_)
-      finalizer_();
+    run_finalizer_();
   }
 
   void join_threads_() {
@@ -234,21 +359,70 @@ private:
     std::unique_lock<std::mutex> lock(mtx_);
     status_ = stopped;
   }
+
+  bool run_initializer_() {
+    try {
+      return !initializer_ || initializer_();
+    } catch (...) {
+      return false;
+    }
+  }
+
+  void run_finalizer_() {
+    try {
+      if (finalizer_)
+        finalizer_();
+    } catch (...) {
+    }
+  }
+
+  void notify_worker_started_() {
+    std::unique_lock<std::mutex> lock(mtx_);
+    ++started_workers_;
+    start_cv_.notify_all();
+  }
+
+  void notify_worker_start_failed_() {
+    std::unique_lock<std::mutex> lock(mtx_);
+    start_failed_ = true;
+    start_cv_.notify_all();
+  }
+
+  template <typename T>
+  static void set_task_value_(std::promise<T> &promise, std::function<T()> &fn) {
+    promise.set_value(fn());
+  }
+
+  static void set_task_value_(std::promise<void> &promise,
+                              std::function<void()> &fn) {
+    fn();
+    promise.set_value();
+  }
+
+  template <typename T>
+  static std::shared_ptr<queued_task<T>> make_task_(std::function<T()> fn) {
+    return std::make_shared<queued_task<T>>(fn);
+  }
+
 #if !defined(__cpp_lambdas)
   bool wait_() { return !queue_.empty() || status_ != running; }
-  static void push_task_(std::shared_ptr<std::packaged_task<void>> task) {
-    (*task)();
+  bool start_wait_() {
+    return start_failed_ || started_workers_ == starting_workers_;
   }
 #endif
 
 private:
   std::mutex mtx_;
   std::condition_variable cv_;
-  std::queue<std::function<void()>> queue_;
+  std::condition_variable start_cv_;
+  std::queue<std::shared_ptr<queued_task_base>> queue_;
   std::vector<std::thread> threads_;
   initialize_callback initializer_;
   finalize_callback finalizer_;
   size_t pool_size_;
+  size_t starting_workers_;
+  size_t started_workers_;
+  bool start_failed_;
   enum status status_;
 };
 } // namespace ext

--- a/test/thread_pool.cpp
+++ b/test/thread_pool.cpp
@@ -4,6 +4,7 @@
 #if defined(_EXT_THREAD_POOL_)
 #include <atomic>
 #include <future>
+#include <stdexcept>
 
 TEST(thread_pool_test, worker_callbacks_are_called) {
   std::atomic<int> initialized(0);
@@ -39,5 +40,49 @@ TEST(thread_pool_test, stop_without_wait_is_joined_by_destructor) {
     EXPECT_EQ(ext::thread_pool::stop_pending, pool.status());
   }
   SUCCEED();
+}
+
+TEST(thread_pool_test, cancellable_task_can_be_canceled_before_execution) {
+  ext::thread_pool pool(1);
+  std::promise<void> release;
+  std::shared_future<void> release_future = release.get_future().share();
+
+  std::future<void> blocker = pool.queue([release_future]() {
+    release_future.wait();
+  });
+
+  ext::thread_pool::queue_item<int> item =
+      pool.queue_cancellable([]() { return 42; });
+  std::future<int> result = item.get_future();
+
+  EXPECT_TRUE(item.cancel());
+  EXPECT_TRUE(item.canceled());
+
+  release.set_value();
+  blocker.get();
+  pool.stop();
+
+  EXPECT_THROW(result.get(), ext::thread_pool::task_canceled);
+}
+
+TEST(thread_pool_test, worker_initializer_failure_stops_pool) {
+  std::atomic<int> initialized(0);
+  std::atomic<int> finalized(0);
+
+  ext::thread_pool pool(
+      [&initialized]() {
+        ++initialized;
+        return false;
+      },
+      [&finalized]() {
+        ++finalized;
+        return true;
+      });
+
+  EXPECT_FALSE(pool.start(2));
+  EXPECT_EQ(ext::thread_pool::stopped, pool.status());
+  EXPECT_GE(initialized.load(), 1);
+  EXPECT_EQ(0, finalized.load());
+  EXPECT_THROW(pool.queue([]() {}), std::runtime_error);
 }
 #endif


### PR DESCRIPTION
## Summary
- implement `thread_pool::queue_item::cancel()` for tasks that have not started running
- add `queue_cancellable()` so callers can obtain a `queue_item<T>` and cancel pending work
- complete canceled task futures with `ext::thread_pool::task_canceled`
- make worker initializer failure stop startup and return `false` from `start()`
- keep finalizers tied to workers that successfully initialized
- document the cancellable queue and initializer failure contract

## Verification
- `git diff --check`
- Markdown fence/link checks for `README.md` and `docs/**/*.md`
- direct compile/run smoke test with `c++ -std=c++17 -pthread -Iinclude`
- `/tmp/cmake-3.30.5/bin/cmake -S test -B /tmp/ntoskrnl7-ext-build-thread-cancel -DCMAKE_BUILD_TYPE=Release`
- `/tmp/cmake-3.30.5/bin/cmake --build /tmp/ntoskrnl7-ext-build-thread-cancel --config Release -j 2`
- `/tmp/cmake-3.30.5/bin/ctest --test-dir /tmp/ntoskrnl7-ext-build-thread-cancel -C Release --output-on-failure`