### PR TITLE
[codex] Finish remaining API contract gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ ext is best used as a collection of opt-in headers:
 | [collection](docs/api/collection.md) | `<ext/collection>` | Self-registering object collection with shared or exclusive locking around global per-type item lists. |
 | [ini](docs/api/ini.md) | `<ext/ini>` | INI parser and writer backed by nested string maps. |
 | [lang](docs/api/lang.md) | `<ext/lang>` | Korean language helpers for Hangul syllables, postpositions, and native/Sino-Korean number words. |
+| [named_mutex](docs/api/named_mutex.md) | `<ext/named_mutex>` | Cross-process named mutex wrapper for coordinating shared resources and shared-memory payloads. |
 | [observable](docs/api/observable.md) | `<ext/observable>` | Observer pattern base template with automatic unsubscribe on observer or observable destruction. |
 | [path](docs/api/path.md) | `<ext/path>` | Path helpers for existence checks, relative path detection, and path joining. |
 | [pipe](docs/api/pipe.md) | `<ext/pipe>` | Cross-platform anonymous pipe wrapper for narrow and wide byte streams. |

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -10,7 +10,7 @@ threading behavior, see [Portability and API contracts](../portability-and-contr
 - Compatibility: [stl_compat](stl_compat.md), [type_traits](type_traits.md), [typeinfo](typeinfo.md)
 - Text, parsing, and data: [base64](base64.md), [ini](ini.md), [lang](lang.md), [path](path.md), [string](string.md), [uri](uri.md), [version](version.md), [wordexp](wordexp.md)
 - Function and object patterns: [any_function](any_function.md), [callback](callback.md), [chain](chain.md), [collection](collection.md), [observable](observable.md), [property](property.md), [result](result.md), [singleton](singleton.md)
-- Concurrency and IPC: [async_result](async_result.md), [cancelable_thread](cancelable_thread.md), [pipe](pipe.md), [process](process.md), [pstream](pstream.md), [safe_object](safe_object.md), [shared_mem](shared_mem.md), [shared_recursive_mutex](shared_recursive_mutex.md), [thread_pool](thread_pool.md)
+- Concurrency and IPC: [async_result](async_result.md), [cancelable_thread](cancelable_thread.md), [named_mutex](named_mutex.md), [pipe](pipe.md), [process](process.md), [pstream](pstream.md), [safe_object](safe_object.md), [shared_mem](shared_mem.md), [shared_recursive_mutex](shared_recursive_mutex.md), [thread_pool](thread_pool.md)
 
 ## Feature Table
 
@@ -27,6 +27,7 @@ threading behavior, see [Portability and API contracts](../portability-and-contr
 | [collection](collection.md) | `<ext/collection>` | Self-registering object collection with shared or exclusive locking around global per-type item lists. |
 | [ini](ini.md) | `<ext/ini>` | INI parser and writer backed by nested string maps. |
 | [lang](lang.md) | `<ext/lang>` | Korean language helpers for Hangul syllables, postpositions, and native/Sino-Korean number words. |
+| [named_mutex](named_mutex.md) | `<ext/named_mutex>` | Cross-process named mutex wrapper for coordinating shared resources and shared-memory payloads. |
 | [observable](observable.md) | `<ext/observable>` | Observer pattern base template with automatic unsubscribe on observer or observable destruction. |
 | [path](path.md) | `<ext/path>` | Path helpers for existence checks, relative path detection, and path joining. |
 | [pipe](pipe.md) | `<ext/pipe>` | Cross-platform anonymous pipe wrapper for narrow and wide byte streams. |

--- a/docs/api/named_mutex.md
+++ b/docs/api/named_mutex.md
@@ -1,0 +1,65 @@
+# named_mutex
+
+[Back to API reference](README.md)
+
+## Header
+
+`#include <ext/named_mutex>`
+
+## Overview
+
+Provides a small RAII wrapper for cross-process named mutual exclusion. Windows
+uses a native named mutex. POSIX platforms use a named semaphore as a binary
+mutex.
+
+## Key APIs
+
+- `ext::named_mutex(name)` creates or opens a named synchronization object.
+- `lock()` waits until the mutex can be acquired.
+- `try_lock()` attempts to acquire the mutex without blocking.
+- `unlock()` releases a lock acquired by this instance.
+- `valid()` reports whether the native handle is open.
+- `abandoned()` reports whether Windows returned `WAIT_ABANDONED` for the most
+  recent successful lock operation. POSIX always reports false.
+- `unlink()` removes the POSIX named semaphore entry. On Windows, named mutex
+  lifetime is handle-based, so this is a no-op that returns true.
+
+## Behavior Notes
+
+- Names are normalized on POSIX by adding a leading `/` when omitted.
+- The class satisfies the basic lockable shape used by `std::lock_guard`.
+- POSIX named semaphores are not robust mutexes. If a process exits while
+  holding the semaphore, another process may block until application-level
+  recovery runs.
+- POSIX named semaphores do not enforce lock ownership. Callers must pair
+  `lock()` or successful `try_lock()` calls with exactly one `unlock()`.
+- Windows named mutexes can be recursively acquired by the owning thread. Avoid
+  relying on recursion when writing portable code.
+- Use one named mutex per shared resource or shared-memory payload that needs
+  cross-process write synchronization.
+
+## Requirements
+
+- GCC 8.3.0+
+- Clang 10.0+
+- Visual Studio 2010+
+- **std::atomic** required
+
+## Examples
+
+```C++
+#include <ext/named_mutex>
+#include <mutex>
+
+ext::named_mutex mutex("shared-state-lock");
+
+{
+  std::lock_guard<ext::named_mutex> lock(mutex);
+  // Access the protected shared state.
+}
+
+if (mutex.try_lock()) {
+  // Access the protected shared state without blocking.
+  mutex.unlock();
+}
+```

--- a/docs/api/shared_mem.md
+++ b/docs/api/shared_mem.md
@@ -37,6 +37,8 @@ Wraps Windows file mappings and POSIX shared memory objects behind a common acce
   across process boundaries.
 - Synchronization is not provided by `shared_mem<T>`; use an external
   interprocess synchronization primitive when multiple processes can write.
+- `ext::named_mutex` is the companion primitive for portable cross-process
+  write synchronization.
 
 ## Requirements
 
@@ -65,6 +67,29 @@ Wraps Windows file mappings and POSIX shared memory objects behind a common acce
   if (st_mem.created()) {
     st_mem->i = 10;
     st_mem->j = 20;
+  }
+  ```
+
+- Synchronized access
+
+  ```C++
+  #include <ext/named_mutex>
+  #include <ext/shared_mem>
+  #include <mutex>
+
+  struct memory_struct0 {
+    int i;
+    int j;
+  };
+
+  ext::shared_mem<memory_struct0> st_mem("memory_struct0",
+                                         shared_mem_all_access);
+  ext::named_mutex lock("memory_struct0.lock");
+
+  {
+    std::lock_guard<ext::named_mutex> guard(lock);
+    st_mem->i += 1;
+    st_mem->j += 1;
   }
   ```
 

--- a/docs/api/version.md
+++ b/docs/api/version.md
@@ -15,15 +15,20 @@ Represents SemVer-style version numbers with major, minor, patch, prerelease, an
 ## Key APIs
 
 - `ext::version` parses version strings and exposes numeric components.
-- Comparison operators order versions by their parsed fields.
+- Comparison operators order versions by major, minor, patch, and SemVer
+  prerelease precedence.
 - Hash support allows use in hashed containers.
 - `major()`, `minor()`, `patch()`, `prerelease()`, `build_metadata()`, `release()`, and `str()` expose or mutate version state.
 
 ## Behavior Notes
 
 - Invalid version strings throw `std::invalid_argument`.
-- Build metadata is intentionally excluded from equality/hash semantics through `str(false)`.
-- Full prerelease ordering is not implemented; comparison only distinguishes prerelease from released versions when major/minor/patch match.
+- Build metadata is intentionally excluded from precedence, equality, and hash
+  semantics through `str(false)`.
+- Prerelease comparison follows SemVer item 11: dot-separated numeric
+  identifiers compare numerically, numeric identifiers sort before non-numeric
+  identifiers, and a release version has higher precedence than a prerelease
+  version with the same major, minor, and patch.
 
 ## Requirements
 

--- a/docs/portability-and-contracts.md
+++ b/docs/portability-and-contracts.md
@@ -59,6 +59,10 @@ memory should read the API-specific behavior notes.
   recursion is not required.
 - `shared_mem` maps named platform resources. The creating and opening
   processes must agree on the object type layout, name, and lifetime.
+- `named_mutex` coordinates named resources across processes. Windows uses
+  native named mutexes; POSIX uses named semaphores as binary mutexes and does
+  not enforce lock ownership or provide robust-owner recovery if a process exits
+  while holding the lock.
 
 ## Error and Exception Boundaries
 

--- a/include/ext/cancelable_thread
+++ b/include/ext/cancelable_thread
@@ -9,6 +9,9 @@
 #pragma once
 
 #ifdef CXX_USE_BOOST
+#define CXX_USE_STD_ATOMIC
+#include <boost/atomic.hpp>
+
 #define CXX_USE_STD_CHRONO
 #include <boost/chrono/chrono.hpp>
 
@@ -24,7 +27,8 @@
 
 #include "stl_compat"
 
-#if ((!defined(CXX_STD_CHRONO_NOT_SUPPORTED)) || defined(_EXT_STD_CHRONO_)) && \
+#if ((!defined(CXX_STD_ATOMIC_NOT_SUPPORTED)) || defined(_EXT_STD_ATOMIC_)) && \
+    ((!defined(CXX_STD_CHRONO_NOT_SUPPORTED)) || defined(_EXT_STD_CHRONO_)) && \
     ((!defined(CXX_STD_MUTEX_NOT_SUPPORTED)) || defined(_EXT_STD_MUTEX_)) &&   \
     ((!defined(CXX_STD_THREAD_NOT_SUPPORTED)) || defined(_EXT_STD_THREAD_)) && \
     ((!defined(CXX_STD_CONDITION_VARIABLE_NOT_SUPPORTED)) ||                   \
@@ -36,6 +40,9 @@
 #include <memory>
 #include <stdexcept>
 
+#ifndef _EXT_STD_ATOMIC_
+#include <atomic>
+#endif
 #ifndef _EXT_STD_MUTEX_
 #include <mutex>
 #endif
@@ -105,7 +112,7 @@ private:
     if (ctx && ctx->cleanup_) {
       ctx->cleanup_();
       ctx->cleanup_ = NULL;
-      ctx->canceled_ = true;
+      ctx->canceled_.store(true);
       ctx->cv_.notify_all();
     }
   }
@@ -114,14 +121,14 @@ private:
 #ifndef __cpp_lambdas
   void thread_proc_(std::function<void()> fn) {
     try {
-      ready_ = true;
+      ready_.store(true);
       cv_.notify_all();
-      if (cancel_requsted_)
+      if (cancel_requsted_.load())
         throw canceled_exception();
       fn();
-      completed_ = true;
+      completed_.store(true);
     } catch (const canceled_exception &) {
-      canceled_ = true;
+      canceled_.store(true);
     }
     cv_.notify_all();
   }
@@ -144,7 +151,7 @@ public:
         if (ctx && ctx->cleanup_) {
           ctx->cleanup_();
           ctx->cleanup_ = nullptr;
-          ctx->canceled_ = true;
+          ctx->canceled_.store(true);
           ctx->cv_.notify_all();
 #if defined(_WIN32)
           ExitThread(0);
@@ -154,7 +161,7 @@ public:
 
       void (*cancel_routine)(void *) = [](void *ptr) {
         cancelable_thread *ctx = reinterpret_cast<cancelable_thread *>(ptr);
-        ctx->canceled_ = true;
+        ctx->canceled_.store(true);
         ctx->cv_.notify_all();
         if (getenv("WINDIR"))
           throw ext::canceled_exception();
@@ -164,14 +171,14 @@ public:
                            this);
 #endif // EXT_CANCELABLE_THREAD_USE_PTHREAD
       try {
-        ready_ = true;
+        ready_.store(true);
         cv_.notify_all();
-        if (cancel_requsted_)
+        if (cancel_requsted_.load())
           throw canceled_exception();
         fn();
-        completed_ = true;
+        completed_.store(true);
       } catch (const canceled_exception &) {
-        canceled_ = true;
+        canceled_.store(true);
       }
       cv_.notify_all();
 #if EXT_CANCELABLE_THREAD_USE_PTHREAD
@@ -184,11 +191,11 @@ public:
 #endif // !defined(__cpp_lambdas)
   }
 
-  bool ready() const { return ready_; }
+  bool ready() const { return ready_.load(); }
 
-  bool completed() const { return completed_; }
+  bool completed() const { return completed_.load(); }
 
-  bool canceled() const { return canceled_; }
+  bool canceled() const { return canceled_.load(); }
 
   std::thread::native_handle_type native_handle() {
     return thread_.native_handle();
@@ -198,14 +205,14 @@ public:
     if (!thread_.joinable())
       return false;
 
-    cancel_requsted_ = true;
+    cancel_requsted_.store(true);
     std::unique_lock<std::mutex> lk(mtx_);
 #if defined(__cpp_lambdas)
-    cv_.wait(lk, [this]() { return ready_; });
+    cv_.wait(lk, [this]() { return ready_.load(); });
 #else
     cv_.wait(lk, std::bind(&cancelable_thread::ready, this));
 #endif
-    ready_ = false;
+    ready_.store(false);
     cv_.notify_all();
 #if EXT_CANCELABLE_THREAD_USE_PTHREAD
     pthread_cancel(thread_.native_handle());
@@ -254,7 +261,7 @@ public:
       return false;
     if (thread_.joinable())
       thread_.join();
-    return canceled_;
+    return canceled_.load();
   }
 
   bool joinable() const { return thread_.joinable(); }
@@ -268,7 +275,9 @@ public:
   bool wait_for(const std::chrono::duration<_Rep, _Period> &time) {
     std::unique_lock<std::mutex> lk(mtx_);
 #if defined(__cpp_lambdas)
-    return cv_.wait_for(lk, time, [this]() { return completed_ || canceled_; });
+    return cv_.wait_for(lk, time, [this]() {
+      return completed_.load() || canceled_.load();
+    });
 #else
     return cv_.wait_for(lk, time,
                         std::bind(&cancelable_thread::is_wait_, this));
@@ -276,17 +285,17 @@ public:
   }
 
 private:
-  bool is_wait_() { return completed_ || canceled_; }
+  bool is_wait_() { return completed_.load() || canceled_.load(); }
 
   std::thread thread_;
   std::mutex mtx_;
   std::condition_variable cv_;
   std::function<void()> cleanup_;
-  bool ready_;
+  std::atomic_bool ready_;
   bool cancel_immediately_;
-  bool cancel_requsted_;
-  bool canceled_;
-  bool completed_;
+  std::atomic_bool cancel_requsted_;
+  std::atomic_bool canceled_;
+  std::atomic_bool completed_;
 };
 } // namespace ext
 

--- a/include/ext/named_mutex
+++ b/include/ext/named_mutex
@@ -1,0 +1,190 @@
+/**
+ * @file named_mutex
+ * @author Jung-kang Lee (ntoskrnl7@gmail.com)
+ * @brief This module implements a cross-process named mutex.
+ *
+ * @copyright Copyright (c) 2020 C++ Extended template library Authors
+ *
+ */
+#pragma once
+
+#ifdef CXX_USE_BOOST
+#define CXX_USE_STD_ATOMIC
+#include <boost/atomic.hpp>
+#endif // CXX_USE_BOOST
+
+#define CXX_USE_NULLPTR
+#include "stl_compat"
+
+#if ((!defined(CXX_STD_ATOMIC_NOT_SUPPORTED)) || defined(_EXT_STD_ATOMIC_))
+
+#ifndef _EXT_NAMED_MUTEX_
+#define _EXT_NAMED_MUTEX_
+
+#include <stdexcept>
+#include <string>
+
+#ifndef _EXT_STD_ATOMIC_
+#include <atomic>
+#endif
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <errno.h>
+#include <fcntl.h>
+#include <semaphore.h>
+#include <sys/stat.h>
+#endif
+
+namespace ext {
+
+class named_mutex {
+public:
+  explicit named_mutex(const char *name)
+      : name_(normalize_name_(name)), abandoned_(false) {
+#if defined(_WIN32)
+    handle_ = CreateMutexA(NULL, FALSE, name_.c_str());
+    if (handle_ == NULL)
+      throw std::runtime_error("Failed to create named mutex: " + name_);
+#else
+    handle_ = sem_open(name_.c_str(), O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP |
+                                             S_IWGRP | S_IROTH | S_IWOTH,
+                       1);
+    if (handle_ == SEM_FAILED)
+      throw std::runtime_error("Failed to create named mutex: " + name_);
+#endif
+  }
+
+  ~named_mutex() { close(); }
+
+  const std::string &name() const { return name_; }
+
+  bool valid() const {
+#if defined(_WIN32)
+    return handle_ != NULL;
+#else
+    return handle_ != SEM_FAILED;
+#endif
+  }
+
+  bool abandoned() const { return abandoned_.load(); }
+
+  void lock() {
+    ensure_valid_();
+#if defined(_WIN32)
+    DWORD result = WaitForSingleObject(handle_, INFINITE);
+    if (result == WAIT_OBJECT_0) {
+      abandoned_.store(false);
+      return;
+    }
+    if (result == WAIT_ABANDONED) {
+      abandoned_.store(true);
+      return;
+    }
+    throw std::runtime_error("Failed to lock named mutex: " + name_);
+#else
+    while (sem_wait(handle_) == -1) {
+      if (errno == EINTR)
+        continue;
+      throw std::runtime_error("Failed to lock named mutex: " + name_);
+    }
+    abandoned_.store(false);
+#endif
+  }
+
+  bool try_lock() {
+    ensure_valid_();
+#if defined(_WIN32)
+    DWORD result = WaitForSingleObject(handle_, 0);
+    if (result == WAIT_OBJECT_0) {
+      abandoned_.store(false);
+      return true;
+    }
+    if (result == WAIT_ABANDONED) {
+      abandoned_.store(true);
+      return true;
+    }
+    if (result == WAIT_TIMEOUT)
+      return false;
+    throw std::runtime_error("Failed to try-lock named mutex: " + name_);
+#else
+    while (sem_trywait(handle_) == -1) {
+      if (errno == EINTR)
+        continue;
+      if (errno == EAGAIN)
+        return false;
+      throw std::runtime_error("Failed to try-lock named mutex: " + name_);
+    }
+    abandoned_.store(false);
+    return true;
+#endif
+  }
+
+  void unlock() {
+    ensure_valid_();
+#if defined(_WIN32)
+    if (!ReleaseMutex(handle_))
+      throw std::runtime_error("Failed to unlock named mutex: " + name_);
+#else
+    if (sem_post(handle_) == -1)
+      throw std::runtime_error("Failed to unlock named mutex: " + name_);
+#endif
+  }
+
+  void close() {
+#if defined(_WIN32)
+    if (handle_ != NULL) {
+      CloseHandle(handle_);
+      handle_ = NULL;
+    }
+#else
+    if (handle_ != SEM_FAILED) {
+      sem_close(handle_);
+      handle_ = SEM_FAILED;
+    }
+#endif
+  }
+
+  bool unlink() {
+#if defined(_WIN32)
+    return true;
+#else
+    return sem_unlink(name_.c_str()) == 0 || errno == ENOENT;
+#endif
+  }
+
+private:
+  named_mutex(const named_mutex &);
+  named_mutex &operator=(const named_mutex &);
+
+  static std::string normalize_name_(const char *name) {
+    if (name == NULL || *name == '\0')
+      throw std::invalid_argument("Named mutex name must not be empty.");
+
+    std::string normalized(name);
+#if !defined(_WIN32)
+    if (normalized[0] != '/')
+      normalized.insert(0, "/");
+#endif
+    return normalized;
+  }
+
+  void ensure_valid_() const {
+    if (!valid())
+      throw std::runtime_error("Named mutex is closed: " + name_);
+  }
+
+  std::string name_;
+#if defined(_WIN32)
+  HANDLE handle_;
+#else
+  sem_t *handle_;
+#endif
+  std::atomic_bool abandoned_;
+};
+
+} // namespace ext
+
+#endif // _EXT_NAMED_MUTEX_
+#endif

--- a/include/ext/shared_mem
+++ b/include/ext/shared_mem
@@ -268,6 +268,7 @@ inline shared_mem_handle create_shared_mem(const char *name,
   if (handle == -1)
     return shared_mem_handle_null;
   if (ftruncate(handle, length) == -1) {
+    close(handle);
     shm_unlink(name);
     return shared_mem_handle_null;
   }
@@ -336,7 +337,7 @@ class shared_mem_base {
 public:
   shared_mem_base(const char *Name)
       : name_(Name), handle_(shared_mem_handle_null),
-        accessMask_(shared_mem_unspecified)
+        accessMask_(shared_mem_unspecified), size_(0)
 #if defined(_WIN32)
         ,
         lastErrorCode_(ERROR_SUCCESS)

--- a/include/ext/version
+++ b/include/ext/version
@@ -22,6 +22,8 @@
 #define CXX_USE_STD_CSTDINT
 #include "stl_compat"
 #include <cstdint>
+#include <cctype>
+#include <vector>
 
 #if ((!defined(CXX_STD_REGEX_NOT_SUPPORTED)) || defined(_EXT_STD_REGEX_))
 #include "string"
@@ -127,12 +129,6 @@ public:
 
   bool operator!=(const version &rhs) const { return !operator==(rhs); }
 
-  // https://semver.org/#spec-item-11
-  //
-  // TODO
-  // Pre-release value comparison is not implemented yet.
-  // 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta
-  // < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
   bool operator<(const version &rhs) const {
     if (major_ != rhs.major_)
       return major_ < rhs.major_;
@@ -140,7 +136,7 @@ public:
       return minor_ < rhs.minor_;
     if (patch_ != rhs.patch_)
       return patch_ < rhs.patch_;
-    return (!prerelease_.empty()) && rhs.prerelease_.empty();
+    return compare_prerelease_(prerelease_, rhs.prerelease_) < 0;
   }
 
   bool operator>(const version &rhs) const {
@@ -150,7 +146,7 @@ public:
       return minor_ > rhs.minor_;
     if (patch_ != rhs.patch_)
       return patch_ > rhs.patch_;
-    return prerelease_.empty() && !rhs.prerelease_.empty();
+    return compare_prerelease_(prerelease_, rhs.prerelease_) > 0;
   }
 
   bool operator<=(const version &rhs) const {
@@ -210,6 +206,86 @@ public:
   }
 
 private:
+  static bool is_numeric_identifier_(const std::string &identifier) {
+    if (identifier.empty())
+      return false;
+    for (std::string::const_iterator it = identifier.begin();
+         it != identifier.end(); ++it) {
+      if (!std::isdigit(static_cast<unsigned char>(*it)))
+        return false;
+    }
+    return true;
+  }
+
+  static std::vector<std::string> split_prerelease_(
+      const std::string &prerelease) {
+    std::vector<std::string> identifiers;
+    std::string::size_type start = 0;
+
+    while (start <= prerelease.size()) {
+      std::string::size_type dot = prerelease.find('.', start);
+      if (dot == std::string::npos) {
+        identifiers.push_back(prerelease.substr(start));
+        break;
+      }
+
+      identifiers.push_back(prerelease.substr(start, dot - start));
+      start = dot + 1;
+    }
+
+    return identifiers;
+  }
+
+  static int compare_numeric_identifier_(const std::string &lhs,
+                                         const std::string &rhs) {
+    if (lhs.size() != rhs.size())
+      return lhs.size() < rhs.size() ? -1 : 1;
+    if (lhs == rhs)
+      return 0;
+    return lhs < rhs ? -1 : 1;
+  }
+
+  static int compare_prerelease_(const std::string &lhs,
+                                 const std::string &rhs) {
+    if (lhs.empty() && rhs.empty())
+      return 0;
+    if (lhs.empty())
+      return 1;
+    if (rhs.empty())
+      return -1;
+
+    std::vector<std::string> lhs_identifiers = split_prerelease_(lhs);
+    std::vector<std::string> rhs_identifiers = split_prerelease_(rhs);
+    const size_t count = lhs_identifiers.size() < rhs_identifiers.size()
+                             ? lhs_identifiers.size()
+                             : rhs_identifiers.size();
+
+    for (size_t i = 0; i < count; ++i) {
+      const std::string &lhs_identifier = lhs_identifiers[i];
+      const std::string &rhs_identifier = rhs_identifiers[i];
+      const bool lhs_numeric = is_numeric_identifier_(lhs_identifier);
+      const bool rhs_numeric = is_numeric_identifier_(rhs_identifier);
+
+      if (lhs_numeric && rhs_numeric) {
+        int numeric_compare =
+            compare_numeric_identifier_(lhs_identifier, rhs_identifier);
+        if (numeric_compare != 0)
+          return numeric_compare;
+        continue;
+      }
+
+      if (lhs_numeric != rhs_numeric)
+        return lhs_numeric ? -1 : 1;
+
+      if (lhs_identifier != rhs_identifier)
+        return lhs_identifier < rhs_identifier ? -1 : 1;
+    }
+
+    if (lhs_identifiers.size() == rhs_identifiers.size())
+      return 0;
+    return lhs_identifiers.size() < rhs_identifiers.size() ? -1 : 1;
+  }
+
   class major_ major_;
   class minor_ minor_;
   uint64_t patch_;

--- a/test/cancelable_thread.cpp
+++ b/test/cancelable_thread.cpp
@@ -11,19 +11,12 @@
 
 #include <ext/cancelable_thread>
 #include <gtest/gtest.h>
-#include <iostream>
 
 #if defined(_EXT_CANCELABLE_THREAD_)
 class test_class {
 public:
-  test_class(int i, bool &flag) : i_(i), flag_(flag) {
-    std::cout << i << " Constructor\n";
-    flag_ = false;
-  }
-  ~test_class() {
-    std::cout << i_ << " Destructor\n";
-    flag_ = true;
-  }
+  test_class(int i, bool &flag) : i_(i), flag_(flag) { flag_ = false; }
+  ~test_class() { flag_ = true; }
   int i_;
   bool &flag_;
 };
@@ -40,14 +33,10 @@ TEST(cancelable_thread_test, cancel_immediately) {
   ext::cancelable_thread t(
 #if defined(_WIN32)
       [&mtx, &destructor_invoked, &reached]() {
-        std::cout
-            << "cancelable_thread_test::cancel_immediately thread started\n";
         test_class t1(1, destructor_invoked[0]);
         test_class t2(2, destructor_invoked[1]);
 #else
       [&mtx, &reached]() {
-        std::cout
-            << "cancelable_thread_test::cancel_immediately thread started\n";
 #endif
         std::unique_lock<std::mutex> lk(mtx);
         while (true) {
@@ -55,8 +44,6 @@ TEST(cancelable_thread_test, cancel_immediately) {
         }
 
         reached = true;
-        std::cout
-            << "cancelable_thread_test::cancel_immediately thread stopped\n";
       },
       [&mtx]() { mtx.unlock(); });
 
@@ -64,8 +51,6 @@ TEST(cancelable_thread_test, cancel_immediately) {
 
   EXPECT_TRUE(t.joinable());
   t.cancel_request();
-  std::cout
-      << "cancelable_thread_test::cancel_immediately thread cancel_requested\n";
 
   t.join();
   EXPECT_FALSE(t.completed());
@@ -100,7 +85,6 @@ TEST(cancelable_thread_test, cancel) {
   bool reached = false;
   bool destructor_invoked[] = {false, false};
   ext::cancelable_thread t([&mtx, &destructor_invoked, &reached]() {
-    std::cout << "cancelable_thread_test::cancel started\n";
     test_class t1(1, destructor_invoked[0]);
     test_class t2(2, destructor_invoked[1]);
     std::unique_lock<std::mutex> lk(mtx);
@@ -111,16 +95,10 @@ TEST(cancelable_thread_test, cancel) {
       throw ext::canceled_exception();
 #endif
     reached = false;
-    std::cout << "cancelable_thread_test::cancel stopped\n";
   });
-  std::cout << "cancel debug 0" << std::endl;
   std::this_thread::sleep_for(std::chrono::seconds(1));
-  std::cout << "cancel debug 1" << std::endl;
   EXPECT_TRUE(t.joinable());
-  std::cout << "cancel debug 2" << std::endl;
   t.cancel_request();
-  std::cout << "cancelable_thread_test::cancel thread cancel_requested"
-            << std::endl;
 
   t.join();
   EXPECT_FALSE(t.completed());
@@ -144,12 +122,10 @@ void cancel_immediately_test_fn() {
   test_class t1(1, destructor_invoked[0]);
   test_class t2(2, destructor_invoked[1]);
   std::unique_lock<std::mutex> lk(mtx);
-  std::cout << "cancelable_thread_test::cancel_immediately thread started\n";
   while (true) {
     // std::this_thread::yield();
   }
   reached = true;
-  std::cout << "cancelable_thread_test::cancel_immediately thread stopped\n";
 }
 
 TEST(cancelable_thread_test, cancel_immediately) {
@@ -178,7 +154,6 @@ TEST(cancelable_thread_test, cancel_immediately) {
 }
 
 void cancel_test_fn() {
-  std::cout << "cancelable_thread_test::cancel started\n";
   test_class t1(1, destructor_invoked[0]);
   test_class t2(2, destructor_invoked[1]);
   std::unique_lock<std::mutex> lk(mtx);
@@ -187,7 +162,6 @@ void cancel_test_fn() {
     throw ext::canceled_exception();
 
   reached = true;
-  std::cout << "cancelable_thread_test::cancel stopped\n";
 }
 
 TEST(cancelable_thread_test, cancel) {

--- a/test/named_mutex.cpp
+++ b/test/named_mutex.cpp
@@ -1,0 +1,63 @@
+﻿#include <ext/named_mutex>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#ifdef _EXT_NAMED_MUTEX_
+namespace {
+std::string unique_mutex_name() {
+  static std::atomic_uint counter(0);
+  unsigned long long stamp = static_cast<unsigned long long>(
+      std::chrono::steady_clock::now().time_since_epoch().count() %
+      100000000ULL);
+  return "enm" + std::to_string(stamp) + "_" +
+         std::to_string(counter.fetch_add(1));
+}
+} // namespace
+
+TEST(named_mutex_test, locks_across_instances) {
+  std::string name = unique_mutex_name();
+  ext::named_mutex owner(name.c_str());
+  ext::named_mutex contender(name.c_str());
+
+  EXPECT_TRUE(owner.valid());
+  EXPECT_TRUE(contender.valid());
+
+  owner.lock();
+
+  std::atomic_bool acquired(false);
+  std::thread contender_thread([&contender, &acquired]() {
+    acquired.store(contender.try_lock());
+    if (acquired.load())
+      contender.unlock();
+  });
+  contender_thread.join();
+
+  EXPECT_FALSE(acquired.load());
+
+  owner.unlock();
+  EXPECT_TRUE(contender.try_lock());
+  contender.unlock();
+
+  EXPECT_TRUE(owner.unlink());
+}
+
+TEST(named_mutex_test, lock_guard_compatible) {
+  std::string name = unique_mutex_name();
+  ext::named_mutex mutex(name.c_str());
+
+  {
+    std::lock_guard<ext::named_mutex> lock(mutex);
+    EXPECT_FALSE(mutex.abandoned());
+  }
+
+  EXPECT_TRUE(mutex.try_lock());
+  mutex.unlock();
+
+  EXPECT_TRUE(mutex.unlink());
+}
+#endif

--- a/test/version.cpp
+++ b/test/version.cpp
@@ -117,7 +117,28 @@ TEST(version_test, comparison) {
   // 11.4
   // Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta
   // < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0. Pre-release value
-  // comparison is not implemented yet.
+  // comparison follows dot-separated SemVer identifiers.
+  EXPECT_TRUE(ext::version("1.0.0-alpha") <
+              ext::version("1.0.0-alpha.1"));
+  EXPECT_TRUE(ext::version("1.0.0-alpha.1") <
+              ext::version("1.0.0-alpha.beta"));
+  EXPECT_TRUE(ext::version("1.0.0-alpha.beta") <
+              ext::version("1.0.0-beta"));
+  EXPECT_TRUE(ext::version("1.0.0-beta") <
+              ext::version("1.0.0-beta.2"));
+  EXPECT_TRUE(ext::version("1.0.0-beta.2") <
+              ext::version("1.0.0-beta.11"));
+  EXPECT_TRUE(ext::version("1.0.0-beta.11") <
+              ext::version("1.0.0-rc.1"));
+  EXPECT_TRUE(ext::version("1.0.0-rc.1") < ext::version("1.0.0"));
+  EXPECT_TRUE(ext::version("1.0.0-alpha.9") <
+              ext::version("1.0.0-alpha.10"));
+  EXPECT_TRUE(ext::version("1.0.0-alpha.10") >
+              ext::version("1.0.0-alpha.9"));
+  EXPECT_TRUE(ext::version("1.0.0-alpha.1") <
+              ext::version("1.0.0-alpha.beta"));
+  EXPECT_TRUE(ext::version("1.0.0-alpha.beta") >
+              ext::version("1.0.0-alpha.1"));
 }
 
 TEST(version_test, update) {


### PR DESCRIPTION
## Summary
- implement full SemVer prerelease precedence for `ext::version`
- add `ext::named_mutex` for cross-process synchronization and document shared-memory locking usage
- tighten `cancelable_thread` state flags with atomics and remove noisy test logging
- close a POSIX shared-memory handle on `ftruncate` failure and initialize base size state

## Verification
- `git diff --check`
- Markdown fence/link checks for `README.md` and `docs/**/*.md`
- `/tmp/cmake-3.30.5/bin/cmake -S test -B /tmp/ntoskrnl7-ext-build-contract-gaps -DCMAKE_BUILD_TYPE=Release`
- `/tmp/cmake-3.30.5/bin/cmake --build /tmp/ntoskrnl7-ext-build-contract-gaps --config Release -j 2`
- `/tmp/cmake-3.30.5/bin/ctest --test-dir /tmp/ntoskrnl7-ext-build-contract-gaps -C Release --output-on-failure`