### PR TITLE
[codex] Fill API documentation gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ ext is best used as a collection of opt-in headers:
 | [async_result](docs/api/async_result.md) | `<ext/async_result>` | Asynchronous producer/result container with iterator-style consumption and cooperative cancellation flag support. |
 | [base64](docs/api/base64.md) | `<ext/base64>` | Base64 encoder/decoder for strings, wide strings, byte vectors, and trivially copyable objects. |
 | [callback](docs/api/callback.md) | `<ext/callback>` | Multicast callback list with add/remove operators and argument forwarding. |
+| [c_object](docs/api/c_object.md) | `<ext/c_object.h>` | C-compatible scoped object lifetime helpers with initializer/finalizer macros and custom allocation hooks. |
 | [cancelable_thread](docs/api/cancelable_thread.md) | `<ext/cancelable_thread>` | Thread wrapper with deferred and immediate cancellation paths over pthread or Windows primitives. |
 | [cdbg](docs/api/cdbg.md) | `<ext/cdbg>` | Debug stream objects that write through platform debug sinks or console fallback streams. |
 | [chain](docs/api/chain.md) | `<ext/chain>` | Composable chain-of-responsibility helper with typed results, continuation links, and exception-aware result state. |

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -7,7 +7,7 @@ threading behavior, see [Portability and API contracts](../portability-and-contr
 
 ## Feature Groups
 
-- Compatibility: [stl_compat](stl_compat.md), [type_traits](type_traits.md), [typeinfo](typeinfo.md)
+- Compatibility: [c_object](c_object.md), [stl_compat](stl_compat.md), [type_traits](type_traits.md), [typeinfo](typeinfo.md)
 - Text, parsing, and data: [base64](base64.md), [ini](ini.md), [lang](lang.md), [path](path.md), [string](string.md), [uri](uri.md), [version](version.md), [wordexp](wordexp.md)
 - Function and object patterns: [any_function](any_function.md), [callback](callback.md), [chain](chain.md), [collection](collection.md), [observable](observable.md), [property](property.md), [result](result.md), [singleton](singleton.md)
 - Concurrency and IPC: [async_result](async_result.md), [cancelable_thread](cancelable_thread.md), [named_mutex](named_mutex.md), [pipe](pipe.md), [process](process.md), [pstream](pstream.md), [safe_object](safe_object.md), [shared_mem](shared_mem.md), [shared_recursive_mutex](shared_recursive_mutex.md), [thread_pool](thread_pool.md)
@@ -20,6 +20,7 @@ threading behavior, see [Portability and API contracts](../portability-and-contr
 | [async_result](async_result.md) | `<ext/async_result>` | Asynchronous producer/result container with iterator-style consumption and cooperative cancellation flag support. |
 | [base64](base64.md) | `<ext/base64>` | Base64 encoder/decoder for strings, wide strings, byte vectors, and trivially copyable objects. |
 | [callback](callback.md) | `<ext/callback>` | Multicast callback list with add/remove operators and argument forwarding. |
+| [c_object](c_object.md) | `<ext/c_object.h>` | C-compatible scoped object lifetime helpers with initializer/finalizer macros and custom allocation hooks. |
 | [cancelable_thread](cancelable_thread.md) | `<ext/cancelable_thread>` | Thread wrapper with deferred and immediate cancellation paths over pthread or Windows primitives. |
 | [cdbg](cdbg.md) | `<ext/cdbg>` | Debug stream objects that write through platform debug sinks or console fallback streams. |
 | [chain](chain.md) | `<ext/chain>` | Composable chain-of-responsibility helper with typed results, continuation links, and exception-aware result state. |

--- a/docs/api/c_object.md
+++ b/docs/api/c_object.md
@@ -1,0 +1,110 @@
+# c_object
+
+[Back to API reference](README.md)
+
+## Header
+
+`#include <ext/c_object.h>`
+
+## Overview
+
+Provides C-only object-lifetime helpers built around a small header placed
+before the user object. The macros create typed C structs with matching
+initializer/finalizer functions and register allocated objects in a scope list
+so they can be finalized automatically when leaving a safe scope.
+
+## Key APIs
+
+- `object_base` stores per-object `context` and `finalize` callback data.
+- `ext_create_object(type)` creates a typed object and registers it in the
+  current safe scope.
+- `ext_create_object_ex(type, context)` does the same while passing a caller
+  context pointer to the initializer.
+- `ext_delete_object(object)` unregisters, finalizes, frees, and nulls an object
+  pointer.
+- `ext_safe_scope({ ... })` creates a scope context for automatic cleanup.
+- `ext_begin_safe(signature)` and `ext_end_safe()` wrap an entire function body
+  in a safe scope.
+- `ext_safe_fn(ret, prototype, body)` defines a `safe_` prefixed helper function
+  that owns a safe scope.
+- `ext_invoke_safe_fn(fn, ...)` invokes `safe_fn(...)` and registers its returned
+  object in the current safe scope.
+- `ext_return_safe(value)` finalizes all objects in the scope before returning.
+- `ext_return_safe_object(object)` returns one object to the caller and finalizes
+  the other objects in the current scope.
+- `ext_decl_object_type(type, initializer, finalizer, members)` declares a C
+  object type plus `type_initialize` and `type_finalize` functions.
+- `ext_begin_object_type(type)` and `ext_end_object_type(...)` provide the split
+  form for declaring a type.
+
+## Custom Allocation
+
+Define these macros before including `<ext/c_object.h>` to override allocation
+and scope-entry storage:
+
+- `ext_alloc_object_base(object_size, context)`
+- `ext_free_object_base(object, context)`
+- `alloc_scope_entry(size)`
+- `free_scope_entry(entry)`
+
+The test suite uses these hooks to count allocations and verify that safe scopes
+release every registered object.
+
+## Behavior Notes
+
+- The macros require a safe scope variable named `__scope_context__`; create
+  objects only inside `ext_safe_scope`, `ext_begin_safe`/`ext_end_safe`, or
+  `ext_safe_fn` bodies.
+- `ext_create_object` stores `object_base` immediately before the returned
+  object pointer. Use `ext_delete_object`, not raw `free`, for objects created
+  by these helpers.
+- `ext_return_safe_object(object)` transfers exactly one object out of the safe
+  scope. The caller becomes responsible for deleting that returned object in a
+  later safe scope or with `ext_delete_object`.
+- Initializers receive `(self, context)`. Finalizers receive only `self`.
+- This header is C-compatible and is intentionally macro-heavy. Prefer ordinary
+  C++ RAII when writing C++ code.
+
+## Requirements
+
+- C compiler or C++ compiler
+- `malloc`/`free`, unless allocation hooks are overridden
+
+## Examples
+
+```C
+#include <stdlib.h>
+#include <ext/c_object.h>
+
+ext_decl_object_type(
+    sample_object,
+    {
+      self->value = context ? *(int *)context : 0;
+    },
+    {
+      self->value = 0;
+    },
+    {
+      int value;
+    });
+
+ext_begin_safe(int run_sample(void)) {
+  int initial = 42;
+  sample_object_ptr object =
+      ext_create_object_ex(sample_object, &initial);
+
+  if (object->value == 42)
+    ext_return_safe(EXIT_SUCCESS);
+
+  ext_return_safe(EXIT_FAILURE);
+}
+ext_end_safe();
+```
+
+```C
+ext_safe_fn(sample_object_ptr, make_sample(int value), {
+  sample_object_ptr object = ext_create_object(sample_object);
+  object->value = value;
+  ext_return_safe_object(object);
+});
+```

--- a/docs/api/path.md
+++ b/docs/api/path.md
@@ -12,16 +12,30 @@ Adds cross-platform string and wide-string path helpers. Tests cover Windows-sty
 
 ## Key APIs
 
+- `ext::path::seperator<char>()` and `seperator<wchar_t>()` return the platform
+  path separator. The misspelled name is the current public API.
 - `ext::path::basename(path)` and `dirname(path)` split the final component from its parent directory.
 - `ext::path::exists(path)` checks whether a path exists.
 - `ext::path::is_relative(path)` recognizes `./name`, `../name`, `.\name`, and `..\name` as relative path forms.
-- `ext::path::join(base, child, ...)` joins path components while preserving platform-style separators.
+- `ext::path::join(base, child, ...)` joins path components while applying
+  `./` and `../` segments.
+- Overloads exist for `const CharT *` and `std::basic_string<CharT>`.
+- Variadic `join` is used when the compiler supports variadic templates and
+  `std::index_sequence`; otherwise overloads are provided up to four child
+  arguments.
 
 ## Behavior Notes
 
 - Both `std::string` and `std::wstring` path overloads are supported where the platform API allows it.
 - A bare `.` or `..` is not considered a relative path by `is_relative`; the tests require an actual child component.
-- Absolute child paths replace earlier base components in join behavior.
+- `basename` and `dirname` return an empty string when the input has no platform
+  separator.
+- `join` treats `./` as current-directory noise and `../` as a request to move
+  the accumulated path to its dirname before appending the remaining child path.
+- `join` does not perform filesystem canonicalization, symlink resolution, or
+  absolute-path security checks. It is string manipulation.
+- On non-Windows platforms, wide-path `exists` converts through the string
+  conversion helper before calling `stat`.
 
 ## Requirements
 
@@ -34,8 +48,16 @@ Adds cross-platform string and wide-string path helpers. Tests cover Windows-sty
 ```C++
 #include <ext/path>
 
-ext::path::join("aaa", "bbb", "ccc"); // aaa/bbb/ccc
+ext::path::seperator<char>(); // '/' on POSIX, '\\' on Windows
+
+ext::path::basename("/aaa/bbb/file.txt"); // "file.txt"
+ext::path::dirname("/aaa/bbb/file.txt"); // "/aaa/bbb"
+
+ext::path::join("aaa", "bbb", "ccc"); // "aaa/bbb/ccc" on POSIX
+ext::path::join("aaa/bbb", "../ccc"); // "aaa/ccc" on POSIX
+
 ext::path::is_relative("./test"); // true
+ext::path::is_relative("../test"); // true
 ext::path::is_relative("/test"); // false
-ext::path::exists("/test");
+ext::path::exists("/test"); // platform filesystem check
 ```

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -12,18 +12,43 @@ Starts a child command with optional arguments and working directory, exposes pi
 
 ## Key APIs
 
+- `ext::process()` creates a non-running process object.
 - `ext::process(command, arguments, working_directory)` starts a child process.
-- `joinable()` checks whether the child is still running and refreshes exit state when it has ended.
+- On old Windows builds without the variadic expansion path, an overload accepts
+  a custom `CreateProcessA`-compatible function for tests or custom launch
+  behavior.
+- `joinable()` checks whether the child is still running and refreshes exit
+  state when it has ended.
 - `join()` waits for completion and closes pipe streams.
+- `detach()` releases process ownership. On POSIX it starts a detached waiter to
+  reap the child.
+- `kill()` terminates the child with `TerminateProcess` on Windows or
+  `SIGKILL` on POSIX.
 - `in()`, `out()`, and `err()` expose process stdin, stdout, and stderr streams.
 - `get_id()`, `native_handle()`, `exit_code()`, and `last_error()` expose process metadata.
-- `get_cmdline()`, `get_cwd()`, and `ext::this_process` helpers expose command-line and working-directory details.
+- `get_cmdline()` returns the command plus arguments assembled by this wrapper.
+- `get_cwd()` returns the working directory requested for this child.
+- `operator|` connects stdout from one process into stdin of the next process
+  and returns the right-hand process as the pipeline result.
+- `ext::this_process::get_id()`, `get_cmdline()`, and `get_cwd()` expose
+  information about the current process.
 
 ## Behavior Notes
 
 - The destructor calls `std::terminate()` if the process is still joinable, mirroring `std::thread`-style ownership rules.
 - The class is move-only on modern compilers and supports `operator|` to connect stdout to the next process stdin.
 - The implementation uses Windows process APIs on Windows and `fork`/`exec`/`waitpid`-style behavior on POSIX systems.
+- Constructor launch failures are reflected through `last_error()`. Calling
+  `in()`, `out()`, or `err()` after a launch failure throws `std::runtime_error`.
+- `joinable()` is not only a query: it may observe child completion, close pipe
+  streams, update `exit_code()`, and mark the object non-joinable.
+- `exit_code()` defaults to success before a child is launched or observed.
+  Read it after `join()` or after `joinable()` has refreshed a completed child.
+- `kill()` only requests termination. Call `join()` afterward if this object
+  still owns the child.
+- Pipeline support is eager: `rhs.in() << lhs.out().rdbuf()` copies stdout in
+  the parent process, closes the right-hand stdin, detaches the left-hand
+  process, and returns the right-hand process.
 
 ## Lifetime Contract
 
@@ -33,6 +58,8 @@ Starts a child command with optional arguments and working directory, exposes pi
   writes enough data to a pipe can block if the parent never drains it.
 - `exit_code()` is meaningful after the process has finished and join state has
   been refreshed.
+- Do not ignore a live `ext::process` object. Join, detach, kill-and-join, or
+  move it before destruction.
 
 ## Requirements
 
@@ -50,6 +77,27 @@ Starts a child command with optional arguments and working directory, exposes pi
   ext::process process("ls", {"-al", "."});
   std::cout << process.get_cmdline() << std::endl;
   std::cout << process.out().rdbuf() << std::endl;
+  if (process.joinable())
+    process.join();
+  ```
+
+- current process
+
+  ```C++
+  #include <ext/process>
+
+  ext::process::id pid = ext::this_process::get_id();
+  std::string executable = ext::this_process::get_cmdline();
+  std::string cwd = ext::this_process::get_cwd();
+  ```
+
+- kill and join
+
+  ```C++
+  #include <ext/process>
+
+  ext::process process("sleep", {"30"});
+  process.kill();
   if (process.joinable())
     process.join();
   ```

--- a/docs/api/string.md
+++ b/docs/api/string.md
@@ -12,17 +12,47 @@ Collects helpers under `ext::string` for common string transformations and compa
 
 ## Key APIs
 
-- `printable`, `lprintable`, and `rprintable` remove non-printable characters.
-- `trim`, `ltrim`, and `rtrim` remove whitespace from strings.
-- `replace_all`, `split`, `starts_with`, `equal`, and search helpers cover common text operations.
-- `stoul` and `stoull` provide unsigned numeric parsing compatibility.
-- `to_u8string`, `from_u8`, and `from_u8string` bridge UTF-8 string types.
+- `ext::string::printable`, `lprintable`, and `rprintable` remove
+  non-printable characters from the whole string, left edge, or right edge.
+- `ext::string::trim`, `ltrim`, and `rtrim` remove whitespace from the whole
+  string, left edge, or right edge.
+- `ext::string::search(text, needle, case_sensitive)` returns whether a needle
+  appears in text. Matching is ASCII case-insensitive by default.
+- `ext::string::starts_with(text, prefix, case_sensitive)` checks a prefix.
+- `ext::string::equal(lhs, rhs, case_sensitive)` compares full strings.
+- `ext::string::replace_all(text, old, replacement, case_sensitive)` replaces
+  every occurrence of a string.
+- `ext::string::split(text, delimiter)` returns non-empty string tokens.
+- `ext::string::split<T>(text, delimiter, converter)` maps non-empty tokens
+  through a converter callback.
+- `ext::string::back(text)` returns the last character or zero for an empty
+  string.
+- `ext::string::convert(src, dst, locale)` converts between `std::string` and
+  `std::wstring`.
+- `ext::string::convert<DstChar>(src, locale)` returns a converted string or
+  throws when exceptions are enabled.
+- `operator!(std::string)` and `operator!(std::wstring)` are shorthand
+  conversions between narrow and wide strings.
+- `ext::from_u8`, `from_u8string`, and `to_u8string` bridge UTF-8 string types
+  when `CXX_USE_STD_U8STRING` or native `std::u8string` support is available.
+- `ext::string::basic_string<T>` derives from `std::basic_string<T>` for legacy
+  movable-string compatibility when that compatibility path is enabled.
 
 ## Behavior Notes
 
 - Most helpers are templated for `char` and `wchar_t` string types.
-- In-place overloads mutate the supplied string and const/input overloads return transformed copies.
+- In-place overloads mutate the supplied string and return a reference to it.
+  `const std::basic_string<T>`, pointer, and rvalue overloads return
+  transformed copies where supported by the compiler.
 - The `ext::u8string` fallback uses `unsigned char` storage when native `std::u8string` is unavailable.
+- `search`, `starts_with`, `equal`, and `replace_all` are ASCII
+  case-insensitive by default. Pass `true` for case-sensitive matching.
+- `split` skips empty tokens. For example, splitting `"a,,b"` by `","` returns
+  `{"a", "b"}`.
+- `convert` uses `std::codecvt` with the provided locale. Conversion behavior
+  therefore depends on the platform locale and standard-library support.
+- `from_u8string(..., ignore_errors)` currently substitutes invalid UTF-8
+  sequences with a replacement character in the wide conversion path.
 
 ## Requirements
 
@@ -32,11 +62,48 @@ Collects helpers under `ext::string` for common string transformations and compa
 
 ## Examples
 
-- split
+- Text cleanup and matching
 
   ```C++
-  std::vector<std::string> list = ext::split("a,b,c,d", ",");
+  #include <ext/string>
+
+  std::string text = "\tHello\n";
+  ext::trim(text); // "Hello"
+
+  ext::search("Hello world", "WORLD"); // true
+  ext::search("Hello world", "WORLD", true); // false
+  ext::starts_with("Hello", "he"); // true
+  ext::equal("Value", "value"); // true
+  ```
+
+- replace and split
+
+  ```C++
+  #include <ext/string>
+
+  std::string text = "one two one";
+  ext::replace_all(text, "one", "1");
+  // text == "1 two 1"
+
+  std::vector<std::string> list = ext::split("a,b,,c,d", ",");
   // list == {"a", "b", "c", "d"}
+
+  std::vector<int> numbers =
+      ext::split<int>("1|2|3", "|", [](const std::string &s) {
+        return std::stoi(s);
+      });
+  ```
+
+- narrow/wide conversion
+
+  ```C++
+  #include <ext/string>
+
+  std::wstring wide = ext::string::convert<wchar_t>(std::string("text"));
+  std::string narrow = ext::string::convert<char>(wide);
+
+  std::wstring wide2 = !std::string("text");
+  std::string narrow2 = !wide2;
   ```
 
 - u8string

--- a/docs/api/units.md
+++ b/docs/api/units.md
@@ -11,19 +11,47 @@
 
 ## Overview
 
-Defines unit wrapper types for decimal SI and binary IEC quantities. Tests cover construction, conversion, arithmetic, and suffix-style usage.
+Defines unit constants, typed size wrappers, string formatters, parsers, and
+user-defined literals for decimal SI and binary IEC byte quantities.
 
 ## Key APIs
 
-- `ext::units::si` provides decimal kilo/mega/giga-style units.
-- `ext::units::iec` provides binary kibi/mebi/gibi-style units.
-- Unit values support arithmetic and conversion back to their base numeric representation.
-- Convenience aliases and suffix-like helpers make expressions readable.
+- `ext::units::POLICY` selects unknown, IEC, or SI formatting through
+  `POLICY_UNKNOWN`, `POLICY_IEC`, and `POLICY_SI`.
+- `ext::units::IEC::UNIT` contains `B`, `KiB`, `MiB`, `GiB`, `TiB`, `PiB`,
+  `EiB`, and `UNSPECIFIED`.
+- `ext::units::SI::UNIT` contains `B`, `kB`, `mB`, `gB`, `tB`, `pB`, `eB`, and
+  `UNSPECIFIED`.
+- `ext::units::IEC::size<Unit>` and `ext::units::SI::size<Unit>` store a unit
+  count and convert to byte count, `std::string`, or `std::wstring`.
+- `ext::units::IEC::parse_size<CharT>(bytes, unit)` and
+  `ext::units::SI::parse_size<CharT>(bytes, unit)` return a numeric value plus
+  a unit suffix.
+- `ext::units::IEC::to_string/to_wstring` and
+  `ext::units::SI::to_string/to_wstring` format byte counts with a selected or
+  inferred unit.
+- `ext::units::to_string/to_wstring(bytes, policy)` dispatch to IEC, SI, or raw
+  bytes.
+- `ext::units::to_size_t("2MiB")` and `to_size_t(L"2MiB")` parse IEC, SI, or
+  byte strings into byte counts.
+- `ext::units::IEC::literals` provides `_KiB`, `_MiB`, `_GiB`, `_TiB`, `_PiB`,
+  and `_EiB`.
+- `ext::units::SI::literals` provides `_kB`, `_mB`, `_gB`, `_tB`, `_pB`, and
+  `_eB`.
 
 ## Behavior Notes
 
 - Use SI units for powers of 1000 and IEC units for powers of 1024.
-- The wrappers are compile-time typed so mixed-unit expressions are clearer than raw integers.
+- `B` has the value `0` in both unit enums. It is a sentinel for formatting
+  rather than a multiplier type to instantiate as `size<B>`.
+- `parse_size` and `to_string` choose a larger unit only when the byte count is
+  strictly greater than the threshold, not equal to it.
+- Formatting uses integer division; fractional values are not emitted.
+- `to_size_t` recognizes uppercase IEC prefixes such as `KiB` and lowercase SI
+  prefixes such as `kB`. Unknown suffixes return `0`; malformed numeric text may
+  throw from `std::stoull`.
+- On platforms where global `SIZE_MAX` does not fit the library assumptions,
+  the header aliases `ext::units::size_t` to `unsigned long long`.
 
 ## Requirements
 
@@ -49,8 +77,8 @@ Defines unit wrapper types for decimal SI and binary IEC quantities. Tests cover
   size = 2 * ext::units::SI::tB;
   ext::units::to_string(size, ext::units::POLICY_SI); // "2tB"
   ext::units::to_wstring(size, ext::units::POLICY_SI); // L"2tB"
-  ext::units::IEC::to_string(2 * ext::units::IEC::TiB, ext::units::IEC::KiB); // "2147483648KiB"
-  ext::units::IEC::to_wstring(2 * ext::units::IEC::TiB, ext::units::IEC::KiB); // L"2147483648KiB"
+  ext::units::SI::to_string(size, ext::units::SI::kB); // "2000000000kB"
+  ext::units::SI::to_wstring(size, ext::units::SI::kB); // L"2000000000kB"
   ```
 
 - to_size_t
@@ -94,4 +122,18 @@ Defines unit wrapper types for decimal SI and binary IEC quantities. Tests cover
 
   std::wstring metric_wstr = 5_mB;
   // metric_wstr == L"5mB"
+  ```
+
+- explicit typed unit
+
+  ```C++
+  #include <ext/units>
+
+  ext::units::IEC::size<ext::units::IEC::MiB> cache_size(64);
+
+  size_t bytes = cache_size;
+  // bytes == 64 * ext::units::IEC::MiB
+
+  std::string label = cache_size;
+  // label == "64MiB"
   ```

--- a/docs/api/uri.md
+++ b/docs/api/uri.md
@@ -8,21 +8,48 @@
 
 ## Overview
 
-Parses URI strings into scheme, host, port, path, query, and fragment fields and provides URI/component percent-encoding helpers. Tests cover invalid URIs, literals, query maps, and encoding.
+Parses simple absolute URI strings into scheme, host, port, path, and query
+fields and provides URI/component percent-encoding helpers. Tests cover invalid
+URIs, literals, query maps, and UTF-8 encoding.
 
 ## Key APIs
 
 - `ext::basic_uri<CharT>` stores parsed URI components and the original value.
 - `ext::uri` and `ext::wuri` are narrow and wide aliases.
-- `encode_uri<CharT>(u8_string)` preserves reserved URI characters while escaping others.
-- `encode_uri_component<CharT>(u8_string)` escapes reserved characters for component values.
-- Constructors can append query maps to an existing URI.
+- `ext::encode_uri<CharT>(u8_string)` preserves RFC 3986 reserved characters
+  while escaping other bytes.
+- `ext::encode_uri_component<CharT>(u8_string)` escapes reserved characters for
+  component values.
+- `basic_uri(uri_string)` parses a string containing `://`.
+- `basic_uri(uri_string, query_map)` appends query parameters to the value.
+- `basic_uri(std::u8string)` and `basic_uri(std::u8string, u8query_map)` are
+  available when UTF-8 string support is enabled.
+- `scheme_host_port()` returns the URI prefix through the authority/port section.
+- `valid()` reports whether parsing produced a non-empty value.
+- `operator const string_type &()` exposes the stored URI string.
+- `basic_uri::encode_component(u8_string)` is a static component-encoding
+  convenience wrapper.
+- `ext::literals::operator"" _uri` creates `uri` or `wuri` from string
+  literals when user-defined literals are supported.
 
 ## Behavior Notes
 
 - A URI without `://` is considered invalid and clears `value`.
-- Scheme and host are normalized to lowercase during parsing.
-- Query strings are stored with the leading `?` when present.
+- Scheme and host are normalized to lowercase during parsing. Path and query are
+  kept as provided.
+- The parser recognizes a port only when the authority contains `:port`.
+- Query strings are stored with the leading `?` when present. Query maps append
+  `?key=value&...` to the stored value.
+- The `fragment` field exists but the parser does not currently split `#...`
+  into it.
+- The parser is intentionally lightweight. It does not validate every RFC 3986
+  grammar rule, does not decode percent-encoded input, and does not parse user
+  info or IPv6 authority forms as separate fields.
+- `encode_uri` and `encode_uri_component` operate on bytes from the supplied
+  UTF-8-like string. They emit uppercase percent escapes.
+- Query map constructors append keys and values as provided for `std::string`
+  and `std::wstring` maps. Encode keys and values first when component escaping
+  is required.
 
 ## Requirements
 
@@ -35,6 +62,8 @@ Parses URI strings into scheme, host, port, path, query, and fragment fields and
 - uri
 
   ```C++
+  #include <ext/uri>
+
   ext::uri u("https://localhost:8443/test");
   // u.scheme == "https"
   // u.host == "localhost"
@@ -49,9 +78,25 @@ Parses URI strings into scheme, host, port, path, query, and fragment fields and
   // u.query == "?fred"
   ```
 
+- query map
+
+  ```C++
+  #include <ext/uri>
+
+  ext::uri::query_map query = {
+    {"q", ext::uri::encode_component("hello world")},
+    {"page", "1"},
+  };
+
+  ext::uri u("https://example.com/search", query);
+  // u.value == "https://example.com/search?page=1&q=hello%20world"
+  ```
+
 - wuri
 
   ```C++
+  #include <ext/uri>
+
   ext::wuri u(L"https://localhost:8443/test");
   // u.scheme == L"https"
   // u.host == L"localhost"
@@ -73,8 +118,8 @@ Parses URI strings into scheme, host, port, path, query, and fragment fields and
 
   using namespace ext::literals;
 
-  ext::uri u = "http://test.com:1234/test?key=value&key1=value1"_uri;
-  ext::wuri u = L"http://test.com:1234/test?key=value&key1=value1"_uri;
+  ext::uri narrow = "http://test.com:1234/test?key=value&key1=value1"_uri;
+  ext::wuri wide = L"http://test.com:1234/test?key=value&key1=value1"_uri;
   ```
 
 - encode
@@ -88,11 +133,15 @@ Parses URI strings into scheme, host, port, path, query, and fragment fields and
     (CXX_VER >= __cpp_user_defined_literals)
     const std::u8string uri_u8str = ext::from_u8(u8"https://www.google.com/search?q=한글+english");
   #else
-    const std::u8string uri_u8str =ext::to_u8string(L"https://www.google.com/search?q=한글+english");
+    const std::u8string uri_u8str =
+        ext::to_u8string(L"https://www.google.com/search?q=한글+english");
   #endif
   #else
     const std::u8string uri_u8str = u8"https://www.google.com/search?q=한글+english";
   #endif
-    ext::uri u(uri_u8str);
-    ext::wuri u(uri_u8str);
+    ext::uri narrow(uri_u8str);
+    ext::wuri wide(uri_u8str);
+
+    ext::uri::encode_component("a b+c");
+    // "a%20b%2Bc"
   ```


### PR DESCRIPTION
## Summary
- add missing API documentation for `<ext/c_object.h>` and link it from README/API index
- expand docs for `string`, `path`, `process`, `units`, and `uri` using the public headers as the source of truth
- document behavior details that were previously implicit, including string matching defaults, path join semantics, process lifetime rules, unit parsing, and URI parser limits

## Verification
- `git diff --check`
- Markdown fence check for `README.md` and `docs/**/*.md`
- Markdown local-link check for `README.md` and `docs/**/*.md`
- public-header-to-doc coverage check for `include/ext/*` vs `docs/api/*.md`