### PR TITLE
[codex] Parse URI fragments

### DIFF
--- a/docs/api/uri.md
+++ b/docs/api/uri.md
@@ -8,9 +8,9 @@
 
 ## Overview
 
-Parses simple absolute URI strings into scheme, host, port, path, and query
-fields and provides URI/component percent-encoding helpers. Tests cover invalid
-URIs, literals, query maps, and UTF-8 encoding.
+Parses simple absolute URI strings into scheme, host, port, path, query, and
+fragment fields and provides URI/component percent-encoding helpers. Tests cover
+invalid URIs, literals, query maps, fragments, and UTF-8 encoding.
 
 ## Key APIs
 
@@ -39,9 +39,8 @@ URIs, literals, query maps, and UTF-8 encoding.
   kept as provided.
 - The parser recognizes a port only when the authority contains `:port`.
 - Query strings are stored with the leading `?` when present. Query maps append
-  `?key=value&...` to the stored value.
-- The `fragment` field exists but the parser does not currently split `#...`
-  into it.
+  `?key=value&...` to the stored value before any fragment.
+- Fragment strings are stored with the leading `#` when present.
 - The parser is intentionally lightweight. It does not validate every RFC 3986
   grammar rule, does not decode percent-encoded input, and does not parse user
   info or IPv6 authority forms as separate fields.
@@ -76,6 +75,11 @@ URIs, literals, query maps, and UTF-8 encoding.
   // u.host == "info.example.com"
   // u.path.empty() == true
   // u.query == "?fred"
+
+  u = ext::uri("https://example.com/path?key=value#section-1");
+  // u.path == "/path"
+  // u.query == "?key=value"
+  // u.fragment == "#section-1"
   ```
 
 - query map
@@ -88,8 +92,8 @@ URIs, literals, query maps, and UTF-8 encoding.
     {"page", "1"},
   };
 
-  ext::uri u("https://example.com/search", query);
-  // u.value == "https://example.com/search?page=1&q=hello%20world"
+  ext::uri u("https://example.com/search#results", query);
+  // u.value == "https://example.com/search?page=1&q=hello%20world#results"
   ```
 
 - wuri

--- a/include/ext/uri
+++ b/include/ext/uri
@@ -36,6 +36,7 @@ template <> struct strings<char> {
   }
   static char slash() { return '/'; }
   static char question() { return '?'; }
+  static char hash() { return '#'; }
   static char colon() { return ':'; }
   static char assign() { return '='; }
   static char ampersand() { return '&'; }
@@ -69,6 +70,7 @@ template <> struct strings<wchar_t> {
   }
   static wchar_t slash() { return L'/'; }
   static wchar_t question() { return L'?'; }
+  static wchar_t hash() { return L'#'; }
   static wchar_t colon() { return L':'; }
   static wchar_t assign() { return L'='; }
   static wchar_t ampersand() { return L'&'; }
@@ -193,26 +195,32 @@ template <typename T> struct basic_uri {
     advance(scheme_end_it, scheme_end.length());
 
     typename string_type::const_iterator host_end_it =
-        find(scheme_end_it, uri_str.end(), strings<T>::slash());
-    if (host_end_it == uri_str.end())
-      host_end_it = find(scheme_end_it, uri_str.end(), strings<T>::question());
+        find_authority_end_(scheme_end_it, uri_str.end());
 
     host.reserve(distance(scheme_end_it, host_end_it));
     std::transform(scheme_end_it, host_end_it, back_inserter(host), tolower);
-    if (host_end_it == uri_str.end())
-      return;
     typename string_type::size_type pos = host.find(strings<T>::colon());
     if (pos != string_type::npos) {
       port = static_cast<unsigned short>(std::stoul(host.substr(pos + 1)));
       host.resize(pos);
     }
 
-    typename string_type::const_iterator query_it =
-        find(host_end_it, uri_str.end(), strings<T>::question());
-    path.assign(host_end_it, query_it);
+    if (host_end_it == uri_str.end())
+      return;
 
-    if (query_it != uri_str.end())
-      query.assign(query_it, uri_str.end());
+    typename string_type::const_iterator fragment_it =
+        find(host_end_it, uri_str.end(), strings<T>::hash());
+    typename string_type::const_iterator query_it =
+        find(host_end_it, fragment_it, strings<T>::question());
+
+    if (*host_end_it == strings<T>::slash())
+      path.assign(host_end_it, query_it);
+
+    if (query_it != fragment_it)
+      query.assign(query_it, fragment_it);
+
+    if (fragment_it != uri_str.end())
+      fragment.assign(fragment_it, uri_str.end());
   }
 
   basic_uri(const string_type &uri_str, const query_map &query)
@@ -222,22 +230,23 @@ template <typename T> struct basic_uri {
 #else
       : basic_uri(uri_str) {
 #endif
-    CXX_FOR(typename query_map::value_type q, query) {
-      this->query +=
-          strings<T>::ampersand() + q.first + strings<T>::assign() + q.second;
-    }
-    if (this->query.size() > 2) {
-      this->query = strings<T>::question() + this->query.substr(1);
-      value += this->query;
-    }
+    append_query_(query);
   }
 
   string_type scheme_host_port() {
-    typename string_type::size_type pos = value.find(
-        strings<T>::slash(), scheme.size() + strings<T>::scheme_end().size());
-    if (pos == string_type::npos)
+    const typename string_type::size_type authority_begin =
+        scheme.size() + strings<T>::scheme_end().size();
+    if (value.size() < authority_begin)
       return value;
-    return value.substr(0, pos);
+
+    const string_type &value_ref = value;
+    typename string_type::const_iterator begin =
+        value_ref.begin() + authority_begin;
+    typename string_type::const_iterator end =
+        find_authority_end_(begin, value_ref.end());
+    if (end == value_ref.end())
+      return value;
+    return value.substr(0, distance(value_ref.begin(), end));
   }
 
   void swap(basic_uri &other) {
@@ -270,6 +279,55 @@ template <typename T> struct basic_uri {
     return encode_uri_component<T, std::u8string>(u8_str);
   }
 #endif // defined(_EXT_U8STRING_)
+
+private:
+  static typename string_type::const_iterator
+  min_iterator_(typename string_type::const_iterator lhs,
+                typename string_type::const_iterator rhs,
+                typename string_type::const_iterator end) {
+    if (lhs == end)
+      return rhs;
+    if (rhs == end)
+      return lhs;
+    return lhs < rhs ? lhs : rhs;
+  }
+
+  static typename string_type::const_iterator
+  find_authority_end_(typename string_type::const_iterator begin,
+                      typename string_type::const_iterator end) {
+    typename string_type::const_iterator slash_it =
+        find(begin, end, strings<T>::slash());
+    typename string_type::const_iterator query_it =
+        find(begin, end, strings<T>::question());
+    typename string_type::const_iterator fragment_it =
+        find(begin, end, strings<T>::hash());
+
+    return min_iterator_(min_iterator_(slash_it, query_it, end), fragment_it,
+                         end);
+  }
+
+  void append_query_(const query_map &query_params) {
+    if (query_params.empty())
+      return;
+
+    string_type query_text = query;
+    CXX_FOR(typename query_map::value_type q, query_params) {
+      if (query_text.empty())
+        query_text += strings<T>::question();
+      else
+        query_text += strings<T>::ampersand();
+      query_text += q.first + strings<T>::assign() + q.second;
+    }
+
+    string_type base = value;
+    if (!fragment.empty())
+      base.resize(base.size() - fragment.size());
+    if (!query.empty())
+      base.resize(base.size() - query.size());
+
+    query = query_text;
+    value = base + query + fragment;
+  }
 };
 
 typedef basic_uri<char> uri;

--- a/test/uri.cpp
+++ b/test/uri.cpp
@@ -71,6 +71,28 @@ TEST(uri_test, uri_test) {
   EXPECT_STREQ(u.host.c_str(), "info.example.com");
   EXPECT_TRUE(u.path.empty());
   EXPECT_STREQ(u.query.c_str(), "?fred");
+
+  u = ext::uri("https://localhost:8443#top");
+  EXPECT_STREQ(u.scheme.c_str(), "https");
+  EXPECT_STREQ(u.host.c_str(), "localhost");
+  EXPECT_EQ(u.port, 8443);
+  EXPECT_TRUE(u.path.empty());
+  EXPECT_TRUE(u.query.empty());
+  EXPECT_STREQ(u.fragment.c_str(), "#top");
+  EXPECT_STREQ(u.scheme_host_port().c_str(), "https://localhost:8443");
+
+  u = ext::uri("https://example.com/path?key=value#section-1");
+  EXPECT_STREQ(u.scheme.c_str(), "https");
+  EXPECT_STREQ(u.host.c_str(), "example.com");
+  EXPECT_STREQ(u.path.c_str(), "/path");
+  EXPECT_STREQ(u.query.c_str(), "?key=value");
+  EXPECT_STREQ(u.fragment.c_str(), "#section-1");
+  EXPECT_STREQ(u.scheme_host_port().c_str(), "https://example.com");
+
+  u = ext::uri("https://example.com/path#section?not=query");
+  EXPECT_STREQ(u.path.c_str(), "/path");
+  EXPECT_TRUE(u.query.empty());
+  EXPECT_STREQ(u.fragment.c_str(), "#section?not=query");
 }
 
 TEST(uri_test, wuri_test) {
@@ -96,6 +118,28 @@ TEST(uri_test, wuri_test) {
   EXPECT_STREQ(u.host.c_str(), L"info.example.com");
   EXPECT_TRUE(u.path.empty());
   EXPECT_STREQ(u.query.c_str(), L"?fred");
+
+  u = ext::wuri(L"https://localhost:8443#top");
+  EXPECT_STREQ(u.scheme.c_str(), L"https");
+  EXPECT_STREQ(u.host.c_str(), L"localhost");
+  EXPECT_EQ(u.port, 8443);
+  EXPECT_TRUE(u.path.empty());
+  EXPECT_TRUE(u.query.empty());
+  EXPECT_STREQ(u.fragment.c_str(), L"#top");
+  EXPECT_STREQ(u.scheme_host_port().c_str(), L"https://localhost:8443");
+
+  u = ext::wuri(L"https://example.com/path?key=value#section-1");
+  EXPECT_STREQ(u.scheme.c_str(), L"https");
+  EXPECT_STREQ(u.host.c_str(), L"example.com");
+  EXPECT_STREQ(u.path.c_str(), L"/path");
+  EXPECT_STREQ(u.query.c_str(), L"?key=value");
+  EXPECT_STREQ(u.fragment.c_str(), L"#section-1");
+  EXPECT_STREQ(u.scheme_host_port().c_str(), L"https://example.com");
+
+  u = ext::wuri(L"https://example.com/path#section?not=query");
+  EXPECT_STREQ(u.path.c_str(), L"/path");
+  EXPECT_TRUE(u.query.empty());
+  EXPECT_STREQ(u.fragment.c_str(), L"#section?not=query");
 }
 
 TEST(uri_test, uri_query_map) {
@@ -115,6 +159,14 @@ TEST(uri_test, uri_query_map) {
   EXPECT_STREQ(u.query.c_str(), "?key=value&key1=value1");
   EXPECT_STREQ(u.value.c_str(),
                "http://test.com:1234/test?key=value&key1=value1");
+
+  ext::uri::query_map query2;
+  query2.insert(ext::uri::query_map::value_type("key2", "value2"));
+  u = ext::uri("http://test.com:1234/test?key=value#frag", query2);
+  EXPECT_STREQ(u.query.c_str(), "?key=value&key2=value2");
+  EXPECT_STREQ(u.fragment.c_str(), "#frag");
+  EXPECT_STREQ(u.value.c_str(),
+               "http://test.com:1234/test?key=value&key2=value2#frag");
 }
 
 TEST(uri_test, wuri_query_map) {
@@ -134,6 +186,14 @@ TEST(uri_test, wuri_query_map) {
   EXPECT_STREQ(u.query.c_str(), L"?key=value&key1=value1");
   EXPECT_STREQ(u.value.c_str(),
                L"http://test.com:1234/test?key=value&key1=value1");
+
+  ext::wuri::query_map query2;
+  query2.insert(ext::wuri::query_map::value_type(L"key2", L"value2"));
+  u = ext::wuri(L"http://test.com:1234/test?key=value#frag", query2);
+  EXPECT_STREQ(u.query.c_str(), L"?key=value&key2=value2");
+  EXPECT_STREQ(u.fragment.c_str(), L"#frag");
+  EXPECT_STREQ(u.value.c_str(),
+               L"http://test.com:1234/test?key=value&key2=value2#frag");
 }
 
 TEST(uri_test, uri_encode) {


### PR DESCRIPTION
## Summary
- Parse URI fragments into `basic_uri::fragment` with the leading `#` preserved, matching the existing leading-`?` query behavior.
- Treat `#` as an authority/path/query boundary so host, port, path, query, and `scheme_host_port()` stay correct for fragment-only and query-plus-fragment URIs.
- Make query-map constructors append parameters before an existing fragment and extend an existing query safely.
- Update URI API docs and add narrow/wide tests for fragment parsing and query-map plus fragment behavior.

## Verification
- `git diff --check`
- `/tmp/cmake-3.30.5/bin/cmake -S test -B /tmp/ntoskrnl7-ext-build-uri-fragment -DCMAKE_BUILD_TYPE=Release`
- `/tmp/cmake-3.30.5/bin/cmake --build /tmp/ntoskrnl7-ext-build-uri-fragment --config Release -j 2`
- `/tmp/cmake-3.30.5/bin/ctest --test-dir /tmp/ntoskrnl7-ext-build-uri-fragment -C Release --output-on-failure`